### PR TITLE
Publish via OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write # OIDC — trusted publishing, no stored token
 
     steps:
       - uses: actions/checkout@v4
@@ -17,8 +18,11 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
+
+      - name: Update npm (trusted publishing needs >= 11.5.1)
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
@@ -28,5 +32,3 @@ jobs:
 
       - name: Publish
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@casomoltd/paye-calc",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@casomoltd/paye-calc",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "license": "LGPL-3.0-only",
       "devDependencies": {
         "@casomoltd/tooling": "git+https://github.com/casomoltd/tooling.git#semver:^0.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@casomoltd/paye-calc",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "UK PAYE take-home pay calculator — income tax, NI, pensions, student loans",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "@casomoltd/paye-calc",
   "version": "0.5.9",
   "description": "UK PAYE take-home pay calculator — income tax, NI, pensions, student loans",
+  "homepage": "https://github.com/casomoltd/paye-calc#readme",
+  "bugs": "https://github.com/casomoltd/paye-calc/issues",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -49,7 +51,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "devDependencies": {
     "@casomoltd/tooling": "git+https://github.com/casomoltd/tooling.git#semver:^0.10.0",


### PR DESCRIPTION
Switch publishing to GitHub OIDC trusted publishing — no stored npm token. Merge AFTER the package is bootstrapped on npmjs and its Trusted Publisher is configured; merging publishes 0.5.9 via OIDC.