### PR TITLE
Fix ESM import extension in TaxCode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@casomoltd/paye-calc",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@casomoltd/paye-calc",
-      "version": "0.5.10",
+      "version": "0.5.11",
       "license": "LGPL-3.0-only",
       "devDependencies": {
         "@casomoltd/tooling": "git+https://github.com/casomoltd/tooling.git#semver:^0.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@casomoltd/paye-calc",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "UK PAYE take-home pay calculator — income tax, NI, pensions, student loans",
   "homepage": "https://github.com/casomoltd/paye-calc#readme",
   "bugs": "https://github.com/casomoltd/paye-calc/issues",

--- a/src/TaxCode.ts
+++ b/src/TaxCode.ts
@@ -8,8 +8,8 @@
  * @see https://www.gov.uk/tax-codes/what-your-tax-code-means
  */
 
-import {NATION_KEYS} from './types';
-import type {Nation} from './types';
+import {NATION_KEYS} from './types.js';
+import type {Nation} from './types.js';
 
 /** How income tax should be calculated for this code. */
 export enum TaxStrategy {


### PR DESCRIPTION
TaxCode.js imported './types' without a .js extension — Node ESM consumers (nhs-pay loading the published dist) can't resolve it; hub-site's bundler masked it. Adds the extension. Bumps to 0.5.11. Merging republishes via OIDC; unblocks nhs-pay.