### PR TITLE
ci: publish on tag push, not push to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,13 @@
 name: Publish to npm
 
 on:
+  # Release = a version tag pushed from a maintainer's machine
+  # (npm version patch -> git push --follow-tags). PR merges to
+  # main do NOT publish — only the tag push does — so external
+  # contributions land via PR without triggering a release, and
+  # the local check-version/check-tags hooks stay the gate.
   push:
-    branches: [main]
+    tags: ['v*']
 
 jobs:
   publish:


### PR DESCRIPTION
Decouples **release** from **merging to main** so external-contributor PRs can land without triggering a publish.

- Trigger: `on: push: branches:[main]` → `on: push: tags:['v*']`
- PR merges to main = code review only, **no publish**
- Release stays a local maintainer action: `npm version patch` → `git push --follow-tags`; the **tag push** is the publish trigger, gated by the local `check-version`/`check-tags` hooks
- **OIDC trusted publishing unaffected** — npm matches the workflow *filename*, not the trigger event

Merging this does **not** publish (tag-only trigger, no tag pushed). The new pipeline is exercised on the next real release.